### PR TITLE
feat: use sequences for the buffer datatype

### DIFF
--- a/src/Doc.hs
+++ b/src/Doc.hs
@@ -1,22 +1,25 @@
-module Doc where
+module Doc (Doc (cursor), initDoc, updateDoc, printDoc) where
 
 import Buffer
+import Data.Foldable
+import qualified Data.Sequence as S
 import Keys
 import Utils.ListUtils
 
 data Doc = Doc
-  { content :: [Buffer]
+  { content :: S.Seq Buffer
   , cursor :: (Int, Int)
   , depth :: Int
   }
+  deriving (Show)
 
 initDoc :: Doc
-initDoc = Doc infiniteEmpty (0, 0) 0
+initDoc = Doc emptyBuf (0, 0) 0
 
 updateDoc :: Doc -> Key -> Doc
 updateDoc d k = case k of
   ArrowUp -> changeCursorBy d (-1) 0 -- limit checking here
-  ArrowDown -> changeCursorBy d 1 0
+  ArrowDown -> changeCursorBy d 1 0 -- and here (or inside changerCursorBy)
   ArrowLeft -> changeCursorBy d 0 (-1)
   ArrowRight -> changeCursorBy d 0 1
   NewLine -> setCursorToStart (changeCursorBy d 1 0)
@@ -27,29 +30,41 @@ changeCursorBy :: Doc -> Int -> Int -> Doc
 changeCursorBy d r c = d{cursor = newCursor}
  where
   (x, y) = cursor d
-  le = lineEnd (content d !! (x + r))
+  le =
+    lineEnd
+      ( case S.lookup (x + r) (content d) of
+          Just b -> b
+          _ -> Buffer{lineEnd = 0, before = S.empty, after = S.empty}
+      )
   newCursor = (x + r, min le (y + c))
 
 setCursorToStart :: Doc -> Doc
 setCursorToStart d = d{cursor = (x, 0)}
-  where
-    (x, _) = cursor d
+ where
+  (x, _) = cursor d
 
 insertChar :: Doc -> Char -> Doc
 insertChar d k =
   d
-    { content = replaceAt x (insertAt y k (content d !! x)) (content d)
+    { content = replaceAt x (insertAt y k (S.index contentPrev x)) contentPrev
     , cursor = newCursor
     , depth = max (depth d) x
     }
  where
   (x, y) = cursor d
   newCursor = (x, y + 1)
+  contentPrev = case S.lookup x (content d) of
+    Just _ -> content d
+    Nothing -> 
+        S.insertAt
+          x
+          (Buffer{lineEnd = 0, before = S.empty, after = S.empty})
+          (content d)
 
 deleteChar :: Doc -> Doc
 deleteChar d =
   d
-    { content = replaceAt x (deleteAt y (content d !! x)) (content d)
+    { content = replaceAt x (deleteAt y (S.index (content d) x)) (content d)
     , cursor = newCursor
     , depth = max (depth d) x
     }
@@ -58,7 +73,7 @@ deleteChar d =
   newCursor = (x, y - 1)
 
 printDoc :: Doc -> IO ()
-printDoc doc = printList (take d c)
-  where
-    d = depth doc + 1
-    c = content doc
+printDoc doc = printList (take d (toList c))
+ where
+  d = depth doc + 1
+  c = content doc

--- a/src/Utils/ListUtils.hs
+++ b/src/Utils/ListUtils.hs
@@ -3,10 +3,8 @@ module Utils.ListUtils where
 import Buffer
 import qualified Data.Sequence as Seq
 
-replaceAt :: Int -> a -> [a] -> [a]
-replaceAt _ _ [] = []
-replaceAt 0 x (_ : xs) = x : xs
-replaceAt n x (y : ys) = y : replaceAt (n - 1) x ys
+replaceAt :: Int -> a -> Seq.Seq a -> Seq.Seq a
+replaceAt = Seq.update
 
-infiniteEmpty :: [Buffer]
-infiniteEmpty = Buffer Seq.Empty Seq.Empty 0 : infiniteEmpty
+emptyBuf :: Seq.Seq Buffer
+emptyBuf = Seq.Empty


### PR DESCRIPTION
Previously, the buffer was a list of lines. This commit changes the buffer to a list of sequences. This is a more efficient data structure for the buffer.
closes #1